### PR TITLE
Add CI/CD pipelines for PR checks and releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,28 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+    authors:
+      - dependabot
+      - dependabot[bot]
+  categories:
+    - title: "Breaking Changes"
+      labels:
+        - breaking-change
+        - breaking
+    - title: "New Features"
+      labels:
+        - feature
+        - enhancement
+    - title: "Bug Fixes"
+      labels:
+        - bug
+        - fix
+        - bugfix
+    - title: "Documentation"
+      labels:
+        - documentation
+        - docs
+    - title: "Other Changes"
+      labels:
+        - "*"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,26 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,122 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]*.[0-9]*.[0-9]*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 1.2.3 or 1.2.3-beta.1, without v prefix)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
+
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+            echo "::error::Invalid version: $VERSION (expected semver like 1.2.3 or 1.2.3-beta.1)"
+            exit 1
+          fi
+
+          VERSION_MANIFEST=$(echo "$VERSION" | sed 's/-.*//')
+
+          IS_PRERELEASE=false
+          if echo "$VERSION" | grep -qE -- '-'; then
+            IS_PRERELEASE=true
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "version_manifest=$VERSION_MANIFEST" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+          echo "### Version Info" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Full version:** $VERSION" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Manifest version:** $VERSION_MANIFEST" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Pre-release:** $IS_PRERELEASE" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Update manifest.json version
+        run: |
+          jq --arg v "${{ steps.version.outputs.version_manifest }}" \
+            '.version = $v' src/manifest.json > src/manifest.json.tmp \
+            && mv src/manifest.json.tmp src/manifest.json
+
+      - name: Create extension zip
+        run: |
+          cd src
+          zip -r "../debug-dump-${{ steps.version.outputs.version }}.zip" .
+
+      - name: Generate INSTALL.txt
+        run: |
+          cat > INSTALL.txt << 'EOF'
+          Debug Dump - Chrome Extension
+          Installation & Update Guide
+          =============================
+
+          FRESH INSTALL
+          -------------
+          1. Download and extract the .zip file from this release
+          2. Open Chrome and navigate to chrome://extensions/
+          3. Enable "Developer mode" (toggle in the top-right corner)
+          4. Click "Load unpacked"
+          5. Select the extracted folder (the one containing manifest.json)
+          6. The extension icon will appear in your toolbar
+
+          UPDATE AN EXISTING INSTALL
+          --------------------------
+          1. Download and extract the new .zip file
+          2. Replace the contents of your existing extension folder
+             with the newly extracted files
+          3. Go to chrome://extensions/
+          4. Find "Debug Dump" and click the refresh icon (circular arrow)
+
+          USAGE
+          -----
+          - Click the extension icon to open settings (base path, idle time,
+            capture toggles)
+          - Open DevTools (F12) and go to the "Debug Dump" tab to capture
+          - Keyboard shortcut: Alt+Shift+D (DevTools must be open)
+          EOF
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Debug Dump ${{ steps.version.outputs.tag }}
+          generate_release_notes: true
+          prerelease: ${{ steps.version.outputs.is_prerelease == 'true' }}
+          files: |
+            debug-dump-${{ steps.version.outputs.version }}.zip
+            INSTALL.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,22 +33,29 @@ jobs:
             VERSION="${GITHUB_REF_NAME#v}"
           fi
 
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+          # Reject newlines/carriage returns to prevent output injection
+          if [[ "$VERSION" == *$'\n'* ]] || [[ "$VERSION" == *$'\r'* ]]; then
+            echo "::error::Version must not contain newlines"
+            exit 1
+          fi
+
+          # Validate full string against strict semver pattern
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
             echo "::error::Invalid version: $VERSION (expected semver like 1.2.3 or 1.2.3-beta.1)"
             exit 1
           fi
 
-          VERSION_MANIFEST=$(echo "$VERSION" | sed 's/-.*//')
+          VERSION_MANIFEST="${VERSION%%-*}"
 
           IS_PRERELEASE=false
-          if echo "$VERSION" | grep -qE -- '-'; then
+          if [[ "$VERSION" == *-* ]]; then
             IS_PRERELEASE=true
           fi
 
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "version_manifest=$VERSION_MANIFEST" >> "$GITHUB_OUTPUT"
-          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "version=$VERSION" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "version_manifest=$VERSION_MANIFEST" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
           echo "### Version Info" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Full version:** $VERSION" >> "$GITHUB_STEP_SUMMARY"

--- a/tests/console-hook.test.js
+++ b/tests/console-hook.test.js
@@ -9,7 +9,11 @@ const devtoolsSrc = fs.readFileSync(
 );
 const match = devtoolsSrc.match(/(?:const|let|var)\s+CONSOLE_HOOK_CODE\s*=\s*`([\s\S]*?)`;?/);
 if (!match) throw new Error('Could not extract CONSOLE_HOOK_CODE from devtools.js');
-const HOOK_CODE = match[1];
+// The regex extracts raw source text from a template literal. Template literals
+// process escape sequences (e.g. \\n → \n) but fs.readFileSync preserves the raw
+// bytes. Replicate that single level of escape processing so vm.runInContext
+// compiles the same code that eval() would receive at runtime.
+const HOOK_CODE = match[1].replace(/\\\\/g, '\\');
 
 /**
  * Creates an isolated VM context with mocked window/console,
@@ -378,9 +382,7 @@ describe('Console Hook - Stack Traces', function() {
 
   test('console calls include stackTrace field', function() {
     var ctx = createHookedContext().context;
-    // Wrap in a named function so the stack has enough frames after
-    // slicing the first two lines ("Error" + hook's own frame)
-    vm.runInContext('(function caller() { console.log("test"); })()', ctx);
+    vm.runInContext('console.log("test")', ctx);
     var entry = ctx.window.__debugConsoleLogs[0];
     // stackTrace should be a string (call site stack)
     expect(typeof entry.stackTrace).toBe('string');

--- a/tests/console-hook.test.js
+++ b/tests/console-hook.test.js
@@ -378,7 +378,9 @@ describe('Console Hook - Stack Traces', function() {
 
   test('console calls include stackTrace field', function() {
     var ctx = createHookedContext().context;
-    vm.runInContext('console.log("test")', ctx);
+    // Wrap in a named function so the stack has enough frames after
+    // slicing the first two lines ("Error" + hook's own frame)
+    vm.runInContext('(function caller() { console.log("test"); })()', ctx);
     var entry = ctx.window.__debugConsoleLogs[0];
     // stackTrace should be a string (call site stack)
     expect(typeof entry.stackTrace).toBe('string');


### PR DESCRIPTION
## Summary
- **PR pipeline** (`.github/workflows/pr.yml`) — runs Jest unit tests on every PR to `develop`
- **Release pipeline** (`.github/workflows/release.yml`) — triggers on semver tag push (`v1.2.3`, `v1.2.3-beta.1`) or manual dispatch; builds extension zip, generates INSTALL.txt, publishes GitHub Release with auto-generated notes
- **Release notes config** (`.github/release.yml`) — categorizes changelog into Breaking Changes, Features, Bug Fixes, Docs, Other

Closes #6

## Test plan
- [ ] PR pipeline: self-tests when this PR is opened (check Actions tab)
- [ ] Release pipeline: after merge, test with `workflow_dispatch` (version `1.0.0`) or `git tag v1.0.0 && git push origin v1.0.0`
- [ ] Verify release zip contains `manifest.json` at root with correct version
- [ ] Verify INSTALL.txt is attached and readable
- [ ] Verify pre-release tag (`v1.1.0-alpha.1`) marks release as "Pre-release"

🤖 Generated with [Claude Code](https://claude.com/claude-code)