### PR TITLE
Fix code review issues: dead code, race condition, stackTraceLimit, docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Development
 
-No build system, package manager, or dependencies. Pure vanilla JavaScript loaded directly by the manifest. To develop:
+No build system — pure vanilla JavaScript loaded directly by the manifest. To develop:
 
 1. Open `chrome://extensions/` with Developer Mode enabled
 2. "Load unpacked" pointing to the `src/` directory
 3. After code changes, click the refresh icon on the extension card (or reload the extension)
 
-No tests, linting, or formatting tools are configured.
+### Testing
+
+- **Framework**: Jest (`npm test`)
+- **Tests**: `tests/console-hook.test.js` — unit tests for the console hook injection
+- **CI/CD**: GitHub Actions — PR checks run tests on every PR to `develop`; release pipeline builds zip + GitHub Release on tag push
 
 ## Architecture
 
@@ -28,18 +32,19 @@ No tests, linting, or formatting tools are configured.
 - Captures HAR via `chrome.devtools.network.getHAR()`
 - Monitors network idle via `chrome.devtools.network.onRequestFinished` before collecting data
 - Listens to `chrome.storage.onChanged` to pick up settings/toggles changed via popup and keyboard shortcut triggers
+- Downloads files directly via `chrome.downloads.download()` (bypasses 64MB `sendMessage` limit)
 
 ### Supporting Files
 - **`src/devtools/devtools.js`** — Creates the DevTools panel, injects the console hook (inline via `eval`) on panel show and page navigation
-- **`src/service-worker.js`** — Background worker handling `captureViewport` (tab screenshot) and `dumpAll` (file downloads) messages; relays keyboard shortcut via `sendMessage` + `storage.local.set` (dual delivery)
+- **`src/service-worker.js`** — Background worker handling `captureViewport` (tab screenshot) messages; relays keyboard shortcut via `chrome.storage.local.set`
 
 ### Key Technical Details
 - **Screenshot stitching**: Scrolls page in viewport-sized chunks, hides fixed elements (visibility:hidden) and un-sticks sticky elements (position:relative) for chunks after the first, then composites via canvas accounting for device pixel ratio
 - **Max screenshot height**: 16384px
-- **Downloads**: Uses direct `chrome.downloads.download()` to bypass the 64MB `sendMessage` limit; monitors completion via `chrome.downloads.onChanged`
+- **Downloads**: Panel calls `chrome.downloads.download()` directly; monitors completion via `chrome.downloads.onChanged` (listener registered before download starts to avoid race conditions with instant data: URL completions)
 - **Capture toggles**: 5 toggleable types (har, html, console, meta, screenshot) stored in `chrome.storage.local` as `dumpToggles`; disabled types are skipped in `performCapture()` and shown as yellow "skipped" in progress chips
 - **Clipboard**: DevTools panels block `navigator.clipboard`; workaround uses `chrome.devtools.inspectedWindow.eval()` to write clipboard via the inspected page
-- **Keyboard shortcut**: Dual delivery — `chrome.runtime.sendMessage` (primary) + `chrome.storage.local.set({ triggerDump })` (fallback); works only with DevTools open
+- **Keyboard shortcut**: `chrome.storage.local.set({ triggerDump })` from service worker; `devtools.js` listens via `storage.onChanged` and relays to panel; works only with DevTools open
 - **Settings** stored in `chrome.storage.local`: `basePath` (download folder), `idleTime` (wait seconds), `dumpToggles` (capture type toggles)
 
 ## File Map
@@ -47,8 +52,13 @@ No tests, linting, or formatting tools are configured.
 | File | Role |
 |------|------|
 | `src/manifest.json` | Extension manifest (permissions, entry points) |
-| `src/service-worker.js` | Background: screenshots & file downloads |
+| `src/service-worker.js` | Background: tab screenshots & keyboard shortcut relay |
 | `src/panel.css` | Shared dark-theme styling |
 | `src/popup/popup.html/js` | Settings UI (shared with panel) |
-| `src/devtools/panel.html/js` | DevTools panel UI & dump logic |
-| `src/devtools/devtools.html/js` | DevTools page & panel creation |
+| `src/devtools/panel.html/js` | DevTools panel UI, dump logic & file downloads |
+| `src/devtools/devtools.html/js` | DevTools page, panel creation & console hook injection |
+| `tests/console-hook.test.js` | Unit tests for the console hook |
+| `package.json` | Dev dependencies (Jest) and test script |
+| `.github/workflows/pr.yml` | CI: runs tests on PRs to develop |
+| `.github/workflows/release.yml` | CD: builds zip & creates GitHub Release on tag push |
+| `.github/release.yml` | Auto-generated release notes configuration |

--- a/src/devtools/devtools.js
+++ b/src/devtools/devtools.js
@@ -5,8 +5,7 @@ const CONSOLE_HOOK_CODE = `
   window.__debugConsoleHooked = true;
   window.__debugConsoleLogs = [];
   var MAX_ENTRIES = 1000;
-  var ORIG_STACK_LIMIT = Error.stackTraceLimit;
-  Error.stackTraceLimit = 50;
+  if (!(Error.stackTraceLimit >= 50)) Error.stackTraceLimit = 50;
 
   function pushEntry(level, args, stackTrace) {
     var entry = {

--- a/src/devtools/panel.js
+++ b/src/devtools/panel.js
@@ -174,18 +174,23 @@
       var id = null;
       var settled = false;
       var buffered = [];
+      var timeout = null;
+
+      function cleanup() {
+        settled = true;
+        chrome.downloads.onChanged.removeListener(onChanged);
+        if (timeout) { clearTimeout(timeout); timeout = null; }
+      }
 
       function settle(delta) {
         if (settled || !delta.state) return;
         if (delta.state.current === 'complete') {
-          settled = true;
-          chrome.downloads.onChanged.removeListener(onChanged);
+          cleanup();
           chrome.downloads.search({ id: id }, function(items) {
             resolve(items && items[0] ? items[0].filename : '');
           });
         } else if (delta.state.current === 'interrupted') {
-          settled = true;
-          chrome.downloads.onChanged.removeListener(onChanged);
+          cleanup();
           reject(new Error('Download interrupted'));
         }
       }
@@ -200,12 +205,19 @@
       // completion events on near-instant data: URL downloads
       chrome.downloads.onChanged.addListener(onChanged);
 
+      // Safety timeout to prevent listener leak if download never reaches
+      // a terminal state (should not happen in practice)
+      timeout = setTimeout(function() {
+        if (settled) return;
+        cleanup();
+        reject(new Error('Download timed out: ' + filename));
+      }, 60000);
+
       chrome.downloads.download({
         url: url, filename: filename, conflictAction: 'uniquify', saveAs: false
       }, function(downloadId) {
         if (chrome.runtime.lastError) {
-          settled = true;
-          chrome.downloads.onChanged.removeListener(onChanged);
+          cleanup();
           reject(new Error(chrome.runtime.lastError.message));
           return;
         }

--- a/src/devtools/panel.js
+++ b/src/devtools/panel.js
@@ -171,23 +171,51 @@
 
   function downloadOneFile(url, filename) {
     return new Promise(function(resolve, reject) {
+      var id = null;
+      var settled = false;
+      var buffered = [];
+
+      function settle(delta) {
+        if (settled || !delta.state) return;
+        if (delta.state.current === 'complete') {
+          settled = true;
+          chrome.downloads.onChanged.removeListener(onChanged);
+          chrome.downloads.search({ id: id }, function(items) {
+            resolve(items && items[0] ? items[0].filename : '');
+          });
+        } else if (delta.state.current === 'interrupted') {
+          settled = true;
+          chrome.downloads.onChanged.removeListener(onChanged);
+          reject(new Error('Download interrupted'));
+        }
+      }
+
+      function onChanged(delta) {
+        if (id === null) { buffered.push(delta); return; }
+        if (delta.id !== id) return;
+        settle(delta);
+      }
+
+      // Register listener BEFORE starting download to avoid missing
+      // completion events on near-instant data: URL downloads
+      chrome.downloads.onChanged.addListener(onChanged);
+
       chrome.downloads.download({
         url: url, filename: filename, conflictAction: 'uniquify', saveAs: false
       }, function(downloadId) {
-        if (chrome.runtime.lastError) { reject(new Error(chrome.runtime.lastError.message)); return; }
-        function onChanged(delta) {
-          if (delta.id !== downloadId || !delta.state) return;
-          if (delta.state.current === 'complete') {
-            chrome.downloads.onChanged.removeListener(onChanged);
-            chrome.downloads.search({ id: downloadId }, function(items) {
-              resolve(items && items[0] ? items[0].filename : '');
-            });
-          } else if (delta.state.current === 'interrupted') {
-            chrome.downloads.onChanged.removeListener(onChanged);
-            reject(new Error('Download interrupted'));
-          }
+        if (chrome.runtime.lastError) {
+          settled = true;
+          chrome.downloads.onChanged.removeListener(onChanged);
+          reject(new Error(chrome.runtime.lastError.message));
+          return;
         }
-        chrome.downloads.onChanged.addListener(onChanged);
+        id = downloadId;
+        // Replay any events that arrived before we had the id
+        for (var i = 0; i < buffered.length; i++) {
+          if (buffered[i].id === id) settle(buffered[i]);
+          if (settled) break;
+        }
+        buffered = null;
       });
     });
   }
@@ -525,7 +553,7 @@
     });
   }
 
-  // Separate from sendMsg - doesn't reject on captureVisibleTab errors
+  // Resolves to null on error instead of rejecting
   function captureViewport() {
     return new Promise(function(resolve) {
       chrome.runtime.sendMessage({ action: 'captureViewport', tabId: chrome.devtools.inspectedWindow.tabId }, function(response) {

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,17 +1,10 @@
 chrome.commands.onCommand.addListener(function(command) {
   if (command === 'dump') {
-    chrome.runtime.sendMessage({ action: 'triggerDump' }).catch(function() {});
     chrome.storage.local.set({ triggerDump: Date.now() });
   }
 });
 
 chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
-  if (message.action === 'dumpAll') {
-    handleDump(message)
-      .then(function(result) { sendResponse(result); })
-      .catch(function(err) { sendResponse({ error: err.message }); });
-    return true;
-  }
   if (message.action === 'captureViewport') {
     captureTab(message.tabId)
       .then(function(dataUrl) { sendResponse({ dataUrl: dataUrl }); })
@@ -19,49 +12,6 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
     return true;
   }
 });
-
-function handleDump(message) {
-  var folderName = message.folderName;
-  var files = message.files;
-  var screenshotDataUrl = message.screenshotDataUrl;
-
-  var downloadPromises = [];
-
-  var filenames = Object.keys(files);
-  for (var i = 0; i < filenames.length; i++) {
-    var filename = filenames[i];
-    var content = files[filename];
-    var dataUrl = textToDataUrl(content);
-    downloadPromises.push(downloadFile(dataUrl, folderName + '/' + filename));
-  }
-
-  if (screenshotDataUrl) {
-    downloadPromises.push(downloadFile(screenshotDataUrl, folderName + '/screenshot.jpg'));
-  }
-
-  return Promise.allSettled(downloadPromises).then(function(results) {
-    var failures = results.filter(function(r) { return r.status === 'rejected'; });
-    var succeeded = results.filter(function(r) { return r.status === 'fulfilled'; });
-
-    // Extract absolute folder path from the first successful download
-    var absolutePath = '';
-    if (succeeded.length > 0 && succeeded[0].value) {
-      var filePath = succeeded[0].value;
-      var lastSlash = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
-      if (lastSlash > 0) {
-        absolutePath = filePath.substring(0, lastSlash);
-      }
-    }
-
-    return {
-      success: true,
-      downloadPath: absolutePath || folderName,
-      filesDownloaded: succeeded.length,
-      filesFailed: failures.length,
-      screenshotCaptured: !!screenshotDataUrl
-    };
-  });
-}
 
 // Capture the visible area of a specific tab's window
 function captureTab(tabId) {
@@ -83,45 +33,6 @@ function captureTab(tabId) {
         if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
         else resolve(dataUrl);
       });
-    });
-  });
-}
-
-function textToDataUrl(text) {
-  return 'data:application/octet-stream;base64,' + btoa(unescape(encodeURIComponent(text)));
-}
-
-function downloadFile(dataUrl, filename) {
-  return new Promise(function(resolve, reject) {
-    chrome.downloads.download({
-      url: dataUrl,
-      filename: filename,
-      conflictAction: 'uniquify',
-      saveAs: false
-    }, function(downloadId) {
-      if (chrome.runtime.lastError) {
-        reject(new Error(chrome.runtime.lastError.message));
-        return;
-      }
-      function onChanged(delta) {
-        if (delta.id !== downloadId) return;
-        if (!delta.state) return;
-
-        if (delta.state.current === 'complete') {
-          chrome.downloads.onChanged.removeListener(onChanged);
-          chrome.downloads.search({ id: downloadId }, function(items) {
-            if (items && items[0]) {
-              resolve(items[0].filename);
-            } else {
-              resolve('');
-            }
-          });
-        } else if (delta.state.current === 'interrupted') {
-          chrome.downloads.onChanged.removeListener(onChanged);
-          reject(new Error('Download interrupted: ' + filename));
-        }
-      }
-      chrome.downloads.onChanged.addListener(onChanged);
     });
   });
 }

--- a/tests/console-hook.test.js
+++ b/tests/console-hook.test.js
@@ -374,10 +374,28 @@ describe('Console Hook - Unhandled Promise Rejections', function() {
 // ---- Stack traces & Error.stackTraceLimit ----
 
 describe('Console Hook - Stack Traces', function() {
-  test('sets Error.stackTraceLimit to 50', function() {
+  test('sets Error.stackTraceLimit to at least 50', function() {
     var ctx = createHookedContext().context;
     var limit = vm.runInContext('Error.stackTraceLimit', ctx);
-    expect(limit).toBe(50);
+    expect(limit).toBeGreaterThanOrEqual(50);
+  });
+
+  test('does not lower Error.stackTraceLimit if already >= 50', function() {
+    var eventListeners = {};
+    var context = {
+      window: {
+        addEventListener: function(event, handler) { eventListeners[event] = handler; }
+      },
+      console: {
+        log: function() {}, warn: function() {}, error: function() {},
+        info: function() {}, debug: function() {}
+      }
+    };
+    vm.createContext(context);
+    vm.runInContext('Error.stackTraceLimit = 200', context);
+    vm.runInContext(HOOK_CODE, context);
+    var limit = vm.runInContext('Error.stackTraceLimit', context);
+    expect(limit).toBe(200);
   });
 
   test('console calls include stackTrace field', function() {


### PR DESCRIPTION
## Summary
- **Remove dead code in service-worker.js** — unused `handleDump()`, `downloadFile()`, `textToDataUrl()`, and `sendMessage('triggerDump')` (127 → 39 lines). Closes #9
- **Fix download race condition in panel.js** — register `onChanged` listener before starting download, buffer events until `downloadId` available. Closes #11
- **Fix `Error.stackTraceLimit` mutation** — only increase limit, never decrease; remove unused `ORIG_STACK_LIMIT`. Closes #10
- **Update CLAUDE.md** — reflect testing/CI setup, correct architecture descriptions, expand file map. Closes #8

## Test plan
- [x] All 41 tests pass locally (1 new test added for stackTraceLimit non-lowering)
- [ ] CI pipeline passes
- [ ] Manual test: open DevTools → Debug Dump tab → trigger dump → verify all files download correctly
- [ ] Manual test: verify keyboard shortcut (Alt+Shift+D) still works with DevTools open

🤖 Generated with [Claude Code](https://claude.ai/code)