### PR TITLE
Add Content Security Policy to block outbound network requests

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -22,6 +22,9 @@
       "description": "Dump current page state"
     }
   },
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'none'"
+  },
   "background": {
     "service_worker": "service-worker.js"
   }


### PR DESCRIPTION
## Summary
- Added `content_security_policy` to `manifest.json` with `connect-src 'none'` to provide a browser-enforced guarantee that the extension cannot make any outbound network connections
- Chrome APIs (`chrome.downloads`, `chrome.devtools`, `chrome.tabs`) are unaffected since they bypass CSP

## Test plan
- [ ] Load the extension in Chrome and verify all capture types (HAR, HTML, console, meta, screenshot) still work
- [ ] Verify in DevTools Network tab that no outbound requests are made by the extension
- [ ] Confirm that adding `fetch('https://example.com')` in the panel console is blocked by CSP

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)